### PR TITLE
set uft-8 for csv reader to proper run on windows

### DIFF
--- a/src/main/java/ch/aaap/assignment/raw/CSVUtil.java
+++ b/src/main/java/ch/aaap/assignment/raw/CSVUtil.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.HashSet;
@@ -28,7 +29,7 @@ public class CSVUtil {
   public static Set<CSVPoliticalCommunity> getPoliticalCommunities() {
     try {
       InputStream is = CSVUtil.class.getResourceAsStream(POLITICAL_COMMUNITY_FILE);
-      Reader reader = new InputStreamReader(is);
+      Reader reader = new InputStreamReader(is, StandardCharsets.UTF_8);
       CSVParser parser = new CSVParser(reader, CSVFormat.DEFAULT.withHeader());
       DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 


### PR DESCRIPTION
### Short Description
set uft-8 for csv reader to proper run on windows

kudos 🥇 to @simone-montemezzani-3AP for finding this 👍 

### Checks

- [x] This PR follows the coding guidelines of the project
- [x] This PR fulfills the acceptance criteria defined on the issue
- [x] This PR has been locally tested
- [x] Changes in this PR are unit tested
